### PR TITLE
Ability to add custom CSS files

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,13 @@ Available values : default, green, purple, pink, red, cyan, blue, grey, orange.
 
 ## Add favicon
 Put `favicon.ico` inside `static` folder
+
+
+## Add custom CSS
+You can add your custom CSS files with the `customCss` parameter of the configuration file.
+
+```toml
+customCss = ["css/custom.css", "css/custom2.css"]
+```
+
+Just put your files in `static/css` directory.

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -10,6 +10,7 @@ pygmentsStyle = "monokailight"
 [params]
 externalTitle = "Kraiklyn theme"
 sidebarColor = "default"
+customCss = []
 
 [[menu.shortcuts]]
 name = "Kraiklyn on Github"

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -11,6 +11,9 @@
   <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
   <link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
   <link rel="stylesheet" href="{{ .Site.BaseURL }}css/styles.css">
+  {{ range .Site.Params.customCss -}}
+    <link rel="stylesheet" href="{{ . | absURL }}">
+  {{- end }}
   <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
 
 </head>


### PR DESCRIPTION
Added the `customCss` parameter in "params" so that you can add custom CSS files.

Example:
```toml
customCss = ["css/custom.css", "css/custom2.css"]
```