### PR TITLE
hugo 0.55 compatibility (https://github.com/gohugoio/hugo/releases/ta…

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"{{with .Site.LanguageCode}} xml:lang="{{.}}" lang="{{.}}"{{end}}>
 <head>
-  {{ .Hugo.Generator }}
+  {{ hugo.Generator }}
 
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
@@ -14,7 +14,7 @@
   {{ range .Site.Params.customCss -}}
     <link rel="stylesheet" href="{{ . | absURL }}">
   {{- end }}
-  <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
+  <link href="{{ with .OutputFormats.Get "RSS" }}{{ .RelPermalink }}{{ end }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
 
 </head>
 <body>


### PR DESCRIPTION
hugo 0.55 deprecates Hugo and RSSLink directives: [release notes](https://github.com/gohugoio/hugo/releases/tag/v0.55.0), fix this compatibility problem