### PR TITLE
Fix mixed pages and sections render

### DIFF
--- a/layouts/partials/menu_page_list.html
+++ b/layouts/partials/menu_page_list.html
@@ -1,21 +1,15 @@
-{{ if .Pages }}
     <li>
         <a href="#{{ .Params.anchor }}">{{ .Title }}</a>
+{{ if .Pages }}
         <ul>
-            {{ if .Sections }}
-                {{ range .Sections.ByWeight }}
+            {{ range .Pages.ByWeight }}
+                {{ if .IsSection }}
                     {{ partial "menu_page_list.html" . }}
-                {{ end }}
-            {{ else }}
-                {{ range .Pages.ByWeight }}
+                {{ else }}
                     <li><a href="#{{ .Params.anchor }}">{{ .Title }}</a></li>
                 {{ end }}
             {{ end }}
         </ul>
-    </li>
-{{ else }}
-    <li>
-        <a href="#{{ .Params.anchor }}">{{ .Title }}</a>
-    </li>
 {{ end }}
+    </li>
 

--- a/layouts/partials/section_list.html
+++ b/layouts/partials/section_list.html
@@ -1,15 +1,11 @@
+    {{ partial "section.html" . }}
 {{ if .Pages }}
-    {{ partial "section.html" . }}
-    {{ if .Sections }}
-        {{ range .Sections.ByWeight }}
+    {{ range .Pages.ByWeight }}
+        {{ if .IsSection }}
             {{ partial "section_list.html" . }}
+        {{ else }}
+            {{ partial "section.html" . }}
         {{ end }}
-    {{ else }}
-            {{ range .Pages.ByWeight }}
-                {{ partial "section.html" . }}
-            {{ end }}
     {{ end }}
-{{ else }}
-    {{ partial "section.html" . }}
 {{ end }}
 


### PR DESCRIPTION
If a section is mixed by sub sections and pages, only sections can be rendered.
Fix by ranging them of all pages and distinguishing sections by .IsSection.